### PR TITLE
Use `sysconf(_SC_PAGE_SIZE)` instead of `getpagesize()`.

### DIFF
--- a/src/mmap.cc
+++ b/src/mmap.cc
@@ -96,7 +96,7 @@ NAN_METHOD(Sync) {
     const size_t offset = info[1]->Uint32Value();
     if (length <= offset) {
       return Nan::ThrowRangeError("Offset out of bounds");
-    } else if (offset > 0 && (offset % getpagesize())) {
+    } else if (offset > 0 && (offset % sysconf(_SC_PAGE_SIZE))) {
       return Nan::ThrowRangeError("Offset must be a multiple of page size");
     }
 

--- a/src/mmap.cc
+++ b/src/mmap.cc
@@ -147,7 +147,8 @@ static void Init(Handle<Object> target) {
   target->Set(Nan::New("MS_SYNC").ToLocalChecked(), Nan::New<Number>(MS_SYNC));
   target->Set(Nan::New("MS_INVALIDATE").ToLocalChecked(), Nan::New<Number>(MS_INVALIDATE));
 
-  target->Set(Nan::New("PAGE_SIZE").ToLocalChecked(), Nan::New<Number>(sysconf(_SC_PAGE_SIZE)));
+  target->Set(Nan::New("PAGE_SIZE").ToLocalChecked(), Nan::New<Number>(
+    sysconf(_SC_PAGE_SIZE)));
 }
 
 

--- a/src/mmap.cc
+++ b/src/mmap.cc
@@ -147,7 +147,7 @@ static void Init(Handle<Object> target) {
   target->Set(Nan::New("MS_SYNC").ToLocalChecked(), Nan::New<Number>(MS_SYNC));
   target->Set(Nan::New("MS_INVALIDATE").ToLocalChecked(), Nan::New<Number>(MS_INVALIDATE));
 
-  target->Set(Nan::New("PAGE_SIZE").ToLocalChecked(), Nan::New<Number>(getpagesize()));
+  target->Set(Nan::New("PAGE_SIZE").ToLocalChecked(), Nan::New<Number>(sysconf(_SC_PAGE_SIZE)));
 }
 
 


### PR DESCRIPTION
Although it does still work on most systems, the __POSIX__ `getpagesize(…)` routine is deprecated. It makes more sense to use the more appropriate `sysconf(…)` facility (*i.e.*, `sysconf(_SC_PAGE_SIZE)`) to get the current OS page size.