### PR TITLE
Made the anonymous mapping support a bit better.

### DIFF
--- a/src/mmap.cc
+++ b/src/mmap.cc
@@ -138,7 +138,21 @@ static void Init(Handle<Object> target) {
   target->Set(Nan::New("PROT_WRITE").ToLocalChecked(), Nan::New<Number>(PROT_WRITE));
   target->Set(Nan::New("PROT_EXEC").ToLocalChecked(), Nan::New<Number>(PROT_EXEC));
 
-  target->Set(Nan::New("MAP_ANON").ToLocalChecked(), Nan::New<Number>(MAP_ANON));
+  unsigned int map_anonymous_flag;
+  bool map_anonymous_flag_supported = false;
+#if defined(MAP_ANONYMOUS)
+  map_anonymous_flag = MAP_ANONYMOUS;
+  map_anonymous_flag_supported = true;
+#elif defined(MAP_ANON)
+  map_anonymous_flag = MAP_ANON;
+  map_anonymous_flag_supported = true;
+#else
+  map_anonymous_flag = 0x00;
+#endif
+  const auto map_anonymous_flag_javascript_number = Nan::New<Number>(map_anonymous_flag);
+  target->Set(Nan::New("MAP_ANON").ToLocalChecked(), map_anonymous_flag_javascript_number);
+  target->Set(Nan::New("MAP_ANONYMOUS").ToLocalChecked(), map_anonymous_flag_javascript_number);
+  target->Set(Nan::New("MAP_ANONYMOUS_SUPPORTED").ToLocalChecked(), (map_anonymous_flag_supported) ? Nan::True() : Nan::False());
   target->Set(Nan::New("MAP_PRIVATE").ToLocalChecked(), Nan::New<Number>(MAP_PRIVATE));
   target->Set(Nan::New("MAP_SHARED").ToLocalChecked(), Nan::New<Number>(MAP_SHARED));
   target->Set(Nan::New("MAP_FIXED").ToLocalChecked(), Nan::New<Number>(MAP_FIXED));

--- a/src/mmap.cc
+++ b/src/mmap.cc
@@ -138,7 +138,7 @@ static void Init(Handle<Object> target) {
   target->Set(Nan::New("PROT_WRITE").ToLocalChecked(), Nan::New<Number>(PROT_WRITE));
   target->Set(Nan::New("PROT_EXEC").ToLocalChecked(), Nan::New<Number>(PROT_EXEC));
 
-  Local<Number> map_anonymous_flag_number = Nan::New<Number>(0x00);
+  Local<Number> map_anonymous_flag_number;
   bool map_anonymous_supported = false;
 #if defined(MAP_ANONYMOUS)
   map_anonymous_flag_number = Nan::New<Number>(MAP_ANONYMOUS);
@@ -146,10 +146,15 @@ static void Init(Handle<Object> target) {
 #elif defined(MAP_ANON)
   map_anonymous_flag_number = Nan::New<Number>(MAP_ANON);
   map_anonymous_supported = true;
+#else
+  map_anonymous_flag_number = Nan::New<Number>(0x00);
 #endif
   target->Set(Nan::New("MAP_ANON").ToLocalChecked(), map_anonymous_flag_number);
   target->Set(Nan::New("MAP_ANONYMOUS").ToLocalChecked(), map_anonymous_flag_number);
-  target->Set(Nan::New("MAP_ANONYMOUS_SUPPORTED").ToLocalChecked(), (map_anonymous_supported) ? Nan::True() : Nan::False());
+  target->Set(Nan::New("MAP_ANONYMOUS_SUPPORTED").ToLocalChecked(),
+    (map_anonymous_supported) ?
+      Nan::True() :
+      Nan::False());
   target->Set(Nan::New("MAP_PRIVATE").ToLocalChecked(), Nan::New<Number>(MAP_PRIVATE));
   target->Set(Nan::New("MAP_SHARED").ToLocalChecked(), Nan::New<Number>(MAP_SHARED));
   target->Set(Nan::New("MAP_FIXED").ToLocalChecked(), Nan::New<Number>(MAP_FIXED));

--- a/src/mmap.cc
+++ b/src/mmap.cc
@@ -138,18 +138,18 @@ static void Init(Handle<Object> target) {
   target->Set(Nan::New("PROT_WRITE").ToLocalChecked(), Nan::New<Number>(PROT_WRITE));
   target->Set(Nan::New("PROT_EXEC").ToLocalChecked(), Nan::New<Number>(PROT_EXEC));
 
-  Local<Number> map_anonymous_flag_javascript_number = Nan::New<Number>(0x00);
-  bool map_anonymous_flag_supported = false;
+  Local<Number> map_anonymous_flag_number = Nan::New<Number>(0x00);
+  bool map_anonymous_supported = false;
 #if defined(MAP_ANONYMOUS)
-  map_anonymous_flag_javascript_number = Nan::New<Number>(MAP_ANONYMOUS);
-  map_anonymous_flag_supported = true;
+  map_anonymous_flag_number = Nan::New<Number>(MAP_ANONYMOUS);
+  map_anonymous_supported = true;
 #elif defined(MAP_ANON)
-  map_anonymous_flag_javascript_number = Nan::New<Number>(MAP_ANON);
-  map_anonymous_flag_supported = true;
+  map_anonymous_flag_number = Nan::New<Number>(MAP_ANON);
+  map_anonymous_supported = true;
 #endif
-  target->Set(Nan::New("MAP_ANON").ToLocalChecked(), map_anonymous_flag_javascript_number);
-  target->Set(Nan::New("MAP_ANONYMOUS").ToLocalChecked(), map_anonymous_flag_javascript_number);
-  target->Set(Nan::New("MAP_ANONYMOUS_SUPPORTED").ToLocalChecked(), (map_anonymous_flag_supported) ? Nan::True() : Nan::False());
+  target->Set(Nan::New("MAP_ANON").ToLocalChecked(), map_anonymous_flag_number);
+  target->Set(Nan::New("MAP_ANONYMOUS").ToLocalChecked(), map_anonymous_flag_number);
+  target->Set(Nan::New("MAP_ANONYMOUS_SUPPORTED").ToLocalChecked(), (map_anonymous_supported) ? Nan::True() : Nan::False());
   target->Set(Nan::New("MAP_PRIVATE").ToLocalChecked(), Nan::New<Number>(MAP_PRIVATE));
   target->Set(Nan::New("MAP_SHARED").ToLocalChecked(), Nan::New<Number>(MAP_SHARED));
   target->Set(Nan::New("MAP_FIXED").ToLocalChecked(), Nan::New<Number>(MAP_FIXED));

--- a/src/mmap.cc
+++ b/src/mmap.cc
@@ -138,18 +138,15 @@ static void Init(Handle<Object> target) {
   target->Set(Nan::New("PROT_WRITE").ToLocalChecked(), Nan::New<Number>(PROT_WRITE));
   target->Set(Nan::New("PROT_EXEC").ToLocalChecked(), Nan::New<Number>(PROT_EXEC));
 
-  unsigned int map_anonymous_flag;
+  Local<Number> map_anonymous_flag_javascript_number = Nan::New<Number>(0x00);
   bool map_anonymous_flag_supported = false;
 #if defined(MAP_ANONYMOUS)
-  map_anonymous_flag = MAP_ANONYMOUS;
+  map_anonymous_flag_javascript_number = Nan::New<Number>(MAP_ANONYMOUS);
   map_anonymous_flag_supported = true;
 #elif defined(MAP_ANON)
-  map_anonymous_flag = MAP_ANON;
+  map_anonymous_flag_javascript_number = Nan::New<Number>(MAP_ANON);
   map_anonymous_flag_supported = true;
-#else
-  map_anonymous_flag = 0x00;
 #endif
-  const auto map_anonymous_flag_javascript_number = Nan::New<Number>(map_anonymous_flag);
   target->Set(Nan::New("MAP_ANON").ToLocalChecked(), map_anonymous_flag_javascript_number);
   target->Set(Nan::New("MAP_ANONYMOUS").ToLocalChecked(), map_anonymous_flag_javascript_number);
   target->Set(Nan::New("MAP_ANONYMOUS_SUPPORTED").ToLocalChecked(), (map_anonymous_flag_supported) ? Nan::True() : Nan::False());


### PR DESCRIPTION
While most systems have support for the `MAP_ANONYMOUS`/`MAP_ANON` `mmap(…)` flag, at the __POSIX__ level, such support isn’t guaranteed, so this PR adds a boolean `MAP_ANONYMOUS_SUPPORTED` property to make it easy to check for those who want to be safe to check for support before assuming support. Another thing is that, at least on __Linux__-based systems, `MAP_ANON` is deprecated in favor of `MAP_ANONYMOUS`, so I’ve updated the code to use `MAP_ANONYMOUS` by default instead of `MAP_ANON` (and use `MAP_ANON` if `MAP_ANONYMOUS` isn’t available but `MAP_ANON` is). I’ve also added a `MAP_ANONYMOUS` property (`MAP_ANONYMOUS === MAP_ANON`) for consistency.